### PR TITLE
add analysis gateway events

### DIFF
--- a/core/analyzer/index.ts
+++ b/core/analyzer/index.ts
@@ -20,6 +20,7 @@ import { AnalysisNotification } from '@/gateway/typings/notifications';
 
 import { v4 as uuid } from 'uuid';
 import { MessageContext } from '@/gateway/typings/requests';
+import { Severity } from '@/db/common/Severity';
 
 export interface AnalyzerResult {
   options: IAnalyzerOptions;
@@ -28,6 +29,7 @@ export interface AnalyzerResult {
   problematicChannelIDs: string[];
   problematicDiscordInvites: string[];
   problematicLinks: string[];
+  severity?: Severity;
 }
 
 interface LinkAnalysisResults {
@@ -62,6 +64,8 @@ export class Analyzer {
   private youTubeChannelIDRepository: Repository<YouTubeChannelID>;
   private discordGuildRepository: Repository<DiscordGuild>;
   private linkPatternRepository: Repository<LinkPattern>;
+
+  private severity: Severity | undefined;
 
   constructor(
     groupId: string,
@@ -102,6 +106,21 @@ export class Analyzer {
     this.youTubeChannelIDRepository = db.getRepository(YouTubeChannelID);
     this.linkPatternRepository = db.getRepository(LinkPattern);
     this.discordGuildRepository = db.getRepository(DiscordGuild);
+  }
+
+  private maxSeverity(
+    currentSeverity: Severity | undefined,
+    newSeverity: Severity | undefined,
+  ): Severity | undefined {
+    if (typeof currentSeverity === 'undefined') {
+      return newSeverity;
+    }
+
+    if (typeof newSeverity === 'undefined') {
+      return currentSeverity;
+    }
+
+    return Math.max(currentSeverity, newSeverity);
   }
 
   private _makeFindConditions<
@@ -204,6 +223,7 @@ export class Analyzer {
 
       if (entry) {
         problematicIDs.push(videoId);
+        this.severity = this.maxSeverity(this.severity, entry.severity);
 
         if (!this.greedy) {
           break;
@@ -215,6 +235,7 @@ export class Analyzer {
       const videoUploader = await this.getVideoUploader(videoId);
       if (videoUploader) {
         problematicIDs.push(videoId);
+        this.severity = this.maxSeverity(this.severity, videoUploader.severity);
 
         try {
           await addYouTubeVideoID({
@@ -253,6 +274,7 @@ export class Analyzer {
 
         if (entry) {
           problematicIDs.push(id);
+          this.severity = this.maxSeverity(this.severity, entry.severity);
 
           if (!this.greedy) {
             break;
@@ -294,10 +316,11 @@ export class Analyzer {
         inviteData.guild.id,
         'blacklistedId',
       );
-      const entry = this.discordGuildRepository.findOne({ where });
+      const entry = await this.discordGuildRepository.findOne({ where });
 
       if (entry) {
         problemaicInvites.push(invite);
+        this.severity = this.maxSeverity(this.severity, entry.severity);
 
         if (!this.greedy) {
           break;
@@ -308,22 +331,22 @@ export class Analyzer {
     return problemaicInvites;
   }
 
-  private checkLink(link: string, patterns: RegExp[]): boolean {
-    let found = false;
+  private checkLink(link: string, patterns: RegExp[]): number {
+    let foundIndex = -1;
 
-    for (const pattern of patterns) {
+    for (const [idx, pattern] of patterns.entries()) {
       if (pattern.test(link)) {
-        found = true;
+        foundIndex = idx;
       }
 
       pattern.lastIndex = 0; // might not even need to do this
 
-      if (found) {
+      if (foundIndex !== -1) {
         break;
       }
     }
 
-    return found;
+    return foundIndex;
   }
 
   private async handleLinks(links: string[]): Promise<LinkAnalysisResults> {
@@ -343,68 +366,74 @@ export class Analyzer {
 
       const allEntries = await this.linkPatternRepository.find({ where });
       patterns = allEntries.map((entry) => new RegExp(entry.pattern, 'gm'));
-    }
 
-    for (const link of links) {
-      if (patterns.length && this.checkLink(link, patterns)) {
-        problematicLinks.push(link);
+      for (const link of links) {
+        const foundIndex = this.checkLink(link, patterns);
 
-        if (!this.greedy) {
-          break;
-        }
+        if (foundIndex !== -1) {
+          problematicLinks.push(link);
+          this.severity = this.maxSeverity(
+            this.severity,
+            allEntries[foundIndex].severity,
+          );
 
-        continue;
-      }
-
-      if (this.followRedirects) {
-        const urldata = new URLUtils(link);
-        await urldata.prepare();
-
-        if (urldata.isYouTubeVideo()) {
-          const videoId = URLUtils.extractYouTubeID(urldata.url);
-          const result = await this.handleYouTubeVideos([videoId]);
-
-          if (result.length && !problematicVideoIDs.includes(videoId)) {
-            problematicVideoIDs.push(videoId);
-
-            if (!this.greedy) {
-              break;
-            }
+          if (!this.greedy) {
+            break;
           }
 
           continue;
         }
 
-        if (urldata.isYouTubeChannel()) {
-          const channel = URLUtils.extractYouTubeChannel(urldata.url);
+        if (this.followRedirects) {
+          const urldata = new URLUtils(link);
+          await urldata.prepare();
 
-          if (!channel) {
+          if (urldata.isYouTubeVideo()) {
+            const videoId = URLUtils.extractYouTubeID(urldata.url);
+            const result = await this.handleYouTubeVideos([videoId]);
+
+            if (result.length && !problematicVideoIDs.includes(videoId)) {
+              problematicVideoIDs.push(videoId);
+
+              if (!this.greedy) {
+                break;
+              }
+            }
+
             continue;
           }
 
-          const result = await this.handleYouTubeChannels([channel]);
+          if (urldata.isYouTubeChannel()) {
+            const channel = URLUtils.extractYouTubeChannel(urldata.url);
 
-          if (result.length && !problematicChannelIDs.includes(result[0])) {
-            problematicChannelIDs.push(result[0]);
-
-            if (!this.greedy) {
-              break;
+            if (!channel) {
+              continue;
             }
+
+            const result = await this.handleYouTubeChannels([channel]);
+
+            if (result.length && !problematicChannelIDs.includes(result[0])) {
+              problematicChannelIDs.push(result[0]);
+
+              if (!this.greedy) {
+                break;
+              }
+            }
+
+            continue;
           }
 
-          continue;
-        }
+          if (urldata.isDiscordInvite()) {
+            const invite = URLUtils.extractDiscordInvite(urldata.url);
 
-        if (urldata.isDiscordInvite()) {
-          const invite = URLUtils.extractDiscordInvite(urldata.url);
+            const result = await this.handleDiscordInvites([invite]);
 
-          const result = await this.handleDiscordInvites([invite]);
+            if (result.length && !problematicDiscordInvites.includes(invite)) {
+              problematicDiscordInvites.push(invite);
 
-          if (result.length && !problematicDiscordInvites.includes(invite)) {
-            problematicDiscordInvites.push(invite);
-
-            if (!this.greedy) {
-              break;
+              if (!this.greedy) {
+                break;
+              }
             }
           }
         }
@@ -450,6 +479,7 @@ export class Analyzer {
 
     if (problematicVideoIDs.length && !this.greedy) {
       result.problematic = true;
+      result.severity = this.severity;
       return result;
     }
 
@@ -459,6 +489,7 @@ export class Analyzer {
 
     if (problematicChannelIDs.length && !this.greedy) {
       result.problematic = true;
+      result.severity = this.severity;
       return result;
     }
 
@@ -470,6 +501,7 @@ export class Analyzer {
 
     if (problematicDiscordInvites.length && !this.greedy) {
       result.problematic = true;
+      result.severity = this.severity;
       return result;
     }
 
@@ -498,6 +530,8 @@ export class Analyzer {
       result.problematicDiscordInvites.length > 0 ||
       result.problematicLinks.length > 0;
 
+    result.severity = this.severity;
+
     return result;
   }
 
@@ -515,7 +549,6 @@ export class Analyzer {
       await this.gateway.emit<AnalysisNotification>(
         'analysis',
         {
-          notificationId: uuid(),
           content: this.content,
           messageContext,
           results,

--- a/gateway/handlers/analysis.ts
+++ b/gateway/handlers/analysis.ts
@@ -4,13 +4,14 @@ import { AnalysisRequest } from '../typings/requests';
 import { queueAnalysisMessage } from '@/jobs/queue';
 
 const handler = async (ctx: GatewayContext<AnalysisRequest>) => {
-  const { client, gateway, content, options } = ctx;
+  const { client, gateway, content, options, messageContext } = ctx;
 
   queueAnalysisMessage(gateway, {
     groupId: client.getGroup().id,
     clientSessionId: client.getSessionId(),
     content,
     options,
+    messageContext,
   });
 };
 

--- a/gateway/handlers/analysis.ts
+++ b/gateway/handlers/analysis.ts
@@ -1,0 +1,17 @@
+import { GatewayContext } from '../client';
+import { AnalysisRequest } from '../typings/requests';
+
+import { queueAnalysisMessage } from '@/jobs/queue';
+
+const handler = async (ctx: GatewayContext<AnalysisRequest>) => {
+  const { client, gateway, content, options } = ctx;
+
+  queueAnalysisMessage(gateway, {
+    groupId: client.getGroup().id,
+    clientSessionId: client.getSessionId(),
+    content,
+    options,
+  });
+};
+
+export default handler;

--- a/gateway/index.ts
+++ b/gateway/index.ts
@@ -72,7 +72,7 @@ export class Gateway {
     });
   }
 
-  async emit<T extends GatewayNotification>(
+  async emit<T extends Omit<GatewayNotification, 'notificationId'>>(
     event: string,
     data: T,
     condition?: (client: GatewayClient) => boolean,

--- a/gateway/index.ts
+++ b/gateway/index.ts
@@ -10,7 +10,11 @@ import {
 
 import { GatewayClient } from './client';
 
-import { IdentifyRequest, ReconnectRequest } from './typings/requests';
+import {
+  AnalysisRequest,
+  IdentifyRequest,
+  ReconnectRequest,
+} from './typings/requests';
 import {
   GatewayClientACK,
   GatewayNotification,
@@ -21,6 +25,7 @@ import ackHandler from './handlers/ack';
 import reverseHandler, { IReverseRequest } from './handlers/reverse';
 import identifyHandler from './handlers/identify';
 import reconnectHandler from './handlers/reconnect';
+import analysisHandler from './handlers/analysis';
 
 export class Gateway {
   private wss: Server;
@@ -34,7 +39,7 @@ export class Gateway {
     this.port = port;
 
     this.wss.on('connection', (ws) => {
-      const client = new GatewayClient(ws);
+      const client = new GatewayClient(ws, this);
       this.clients.push(client);
 
       client.on<GatewayClientACK>('ack', ackHandler);
@@ -42,6 +47,7 @@ export class Gateway {
       client.on<IReverseRequest>('reverseMessage', reverseHandler);
       client.on<IdentifyRequest>('identify', identifyHandler);
       client.on<ReconnectRequest>('reconnect', reconnectHandler);
+      client.on<AnalysisRequest>('analysis', analysisHandler);
     });
 
     this.wss.on('error', (error) => {

--- a/gateway/typings/notifications.ts
+++ b/gateway/typings/notifications.ts
@@ -21,7 +21,8 @@ export interface GatewayClientACK {
 
 // The fields contained by a notification the gateway server sends to a client
 // when a new blacklist entry is added.
-export interface BlacklistEntryAddedNotification extends GatewayNotification {
+export interface BlacklistEntryAddedNotification
+  extends Omit<GatewayNotification, 'notificationId'> {
   value: string;
   kind: 'substring' | 'regex';
   blacklist: IAnyBlacklistName;
@@ -33,7 +34,8 @@ export interface BlacklistEntryAddedNotification extends GatewayNotification {
 // The fields contained by a notification the gateway server sends to a client
 // when a blacklist entry is removed. Yes, I know it's exactly the same as the
 // one for adding a new entry.
-export interface BlacklistEntryRemovedNotification extends GatewayNotification {
+export interface BlacklistEntryRemovedNotification
+  extends Omit<GatewayNotification, 'notificationId'> {
   value: string;
   kind: 'substring' | 'regex';
   blacklist: IAnyBlacklistName;
@@ -42,13 +44,16 @@ export interface BlacklistEntryRemovedNotification extends GatewayNotification {
   metadata?: IAnyBlacklistEntry;
 }
 
-export interface AnalysisNotification extends GatewayNotification {
+export interface AnalysisNotification
+  extends Omit<GatewayNotification, 'notificationId'> {
   content: string;
   results: AnalyzerResult;
   messageContext?: MessageContext;
 }
 
-export interface NotificationQueueEntry<T = GatewayNotification> {
+export interface NotificationQueueEntry<
+  T = Omit<GatewayNotification, 'notificationId'>,
+> {
   sessionId: string;
   event: string;
   data: T;

--- a/gateway/typings/notifications.ts
+++ b/gateway/typings/notifications.ts
@@ -1,10 +1,12 @@
 // Type definitions for messages coming FROM the gateway server TO a websocket
 // client WITHOUT a prior gateway request.
 
+import { AnalyzerResult } from '@/core/analyzer';
 import {
   IAnyBlacklistEntry,
   IAnyBlacklistName,
 } from '@/typings/IAnyBlacklistEntry';
+import { MessageContext } from './requests';
 
 // Fields all gateway notifications should have.
 export interface GatewayNotification {
@@ -38,6 +40,12 @@ export interface BlacklistEntryRemovedNotification extends GatewayNotification {
   global: boolean;
   guild?: string;
   metadata?: IAnyBlacklistEntry;
+}
+
+export interface AnalysisNotification extends GatewayNotification {
+  content: string;
+  results: AnalyzerResult;
+  messageContext?: MessageContext;
 }
 
 export interface NotificationQueueEntry<T = GatewayNotification> {

--- a/gateway/typings/requests.ts
+++ b/gateway/typings/requests.ts
@@ -55,9 +55,17 @@ export interface GetBlacklistedGuildsRequest extends GuildRestrictableRequest {}
 export interface GetBlacklistedPhrasesRequest
   extends GuildRestrictableRequest {}
 
+export interface MessageContext {
+  guildId?: string;
+  channelId?: string;
+  messageId?: string;
+  userId?: string;
+}
+
 // Used to request the analysis of a message.
 //   client.on('analysisRequested', (data: AnalysisRequest))
 export interface AnalysisRequest extends GatewayRequest {
   content: string;
+  messageContext?: MessageContext;
   options: IAnalyzerOptions;
 }

--- a/jobs/handlers/analysisHandler.ts
+++ b/jobs/handlers/analysisHandler.ts
@@ -1,0 +1,42 @@
+import { ProcessCallbackFunction } from 'bull';
+
+import { IAnalyzerOptions } from '@/core/analyzer/IAnalyzerOptions';
+import { Analyzer } from '@/core/analyzer';
+import { handleError } from '@/lib/errors';
+
+import { AnalysisRequest } from '@/gateway/typings/requests';
+
+export interface IAnalysisRequest extends AnalysisRequest {
+  groupId: string;
+  clientSessionId: string;
+}
+
+const handler: ProcessCallbackFunction<IAnalysisRequest> = async (
+  job,
+  done,
+) => {
+  const { groupId, clientSessionId, content, options, messageContext } =
+    job.data;
+
+  if (process.env.NODE_ENV !== 'production') {
+    console.log(`[${job.queue.name}] <- received analysis request for`, {
+      content,
+      clientSessionId,
+      groupId,
+    });
+  }
+
+  const analyzer = new Analyzer(groupId, content, options, global.__gateway);
+
+  try {
+    await analyzer.analyzeForGatewayClient(clientSessionId, messageContext);
+
+    return done();
+  } catch (err) {
+    handleError(err);
+
+    return done();
+  }
+};
+
+export default handler;

--- a/pages/api/analyze.ts
+++ b/pages/api/analyze.ts
@@ -1,13 +1,11 @@
 import bar from 'next-bar';
-import { withSentry } from '@sentry/nextjs';
-
-import { ensureAuthenticated } from '@/middleware/auth';
-import { ensureHasAccessToResource } from '@/middleware/permissions';
-
-import * as analyzerController from '@/controllers/analyzer/analyzerController';
 
 export default bar({
-  post: withSentry(
-    ensureAuthenticated(ensureHasAccessToResource(analyzerController.analyze)),
-  ),
+  post: (_, res) => {
+    return res.status(410).json({
+      ok: false,
+      error:
+        'The analysis endpoint is no longer supported. Please use the Nakiri Gateway instead.',
+    });
+  },
 });


### PR DESCRIPTION
You can now send the following request to the Nakiri Gateway:

```json
[ "analysis", { "content": "this is a message" } ]
```

This will queue an analysis of the payload. You can also provide `options` to the event. In addition, you can also provide `messageContext`, which has 4 possible fields: `guildId`, `channelId`, `messageId`, `userId`. This will help you identify the offending message from the response notification.

Also, the analyzer will also report the severity of the message.

The response notification looks like this:

```json
[ "analysis", {
  "ok": true,
  "data": {
    "notificationId": "...",
    "content": "this is a message",
    "messageContext": {
      "guildId": "...",
      "...": "..."
    }
    "results": {},
  }
} ]
```